### PR TITLE
Get FFmpeg to build with Visual Studio 2017

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@
 /src
 /mapfile
 /tools/python/__pycache__/
+/Output/
+/Build/

--- a/Windows/Build.ps1
+++ b/Windows/Build.ps1
@@ -1,0 +1,35 @@
+
+# Set up Visual Studio 2017 (x64) building environment  
+function Invoke-BatchFile
+{
+   param([string]$Path, [string]$Parameters)  
+
+   $tempFile = [IO.Path]::GetTempFileName()  
+
+   ## Store the output of cmd.exe.  We also ask cmd.exe to output   
+   ## the environment table after the batch file completes  
+   cmd.exe /c " `"$Path`" $Parameters && set > `"$tempFile`" " 
+
+   ## Go through the environment variables in the temp file.  
+   ## For each of them, set the variable in our local environment.  
+   Get-Content $tempFile | Foreach-Object {   
+       if ($_ -match "^(.*?)=(.*)$")  
+       { 
+           Set-Content "env:\$($matches[1])" $matches[2]  
+       } 
+   }  
+
+   Remove-Item $tempFile
+}
+Invoke-BatchFile "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+
+# Parse out the folder path of current script file
+$FFmpeg_Source_Folder = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
+write-host $FFmpeg_Source_Folder
+
+write-host Building FFmpeg binaries...
+
+# Start MSYS2 bash environment and build FFmpeg binaries
+Start-Process -FilePath "C:\msys64\msys2_shell.cmd" -ArgumentList "$FFmpeg_Source_Folder\Build.sh" -Wait -NoNewWindow
+
+write-host Done

--- a/Windows/Build.sh
+++ b/Windows/Build.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -x #echo on
+
+FFmpeg_Source_Folder=$(dirname "$(readlink -f "$0")")
+
+cd $FFmpeg_Source_Folder
+cd ..
+rm -rf Output
+rm -rf Build
+
+mkdir -p Output/Release
+cd Output/Release
+
+../../configure \
+--toolchain=msvc \
+--disable-programs \
+--disable-doc \
+--arch=x86_64 \
+--enable-shared \
+--disable-static \
+--enable-cross-compile \
+--target-os=win64 \
+--extra-cflags="-MD" \
+--disable-debug \
+--disable-network \
+--disable-autodetect \
+--disable-encoders \
+--disable-decoders \
+--disable-filters \
+--disable-muxers \
+--disable-demuxers \
+--disable-bsfs \
+--disable-parsers \
+--disable-protocols \
+--disable-devices \
+--enable-protocol=file \
+--enable-decoder=h264,mp3*,aac,pcm*,mpeg4 \
+--enable-demuxer=h264,mp4,mp3,avi,mov,aac \
+--enable-parser=h264,aac,mpeg4video \
+--prefix=../../Build/Release
+
+make -j4
+make install
+
+cd ..
+mkdir -p Debug
+cd Debug
+
+../../configure \
+--toolchain=msvc \
+--disable-programs \
+--disable-doc \
+--arch=x86_64 \
+--enable-shared \
+--disable-static \
+--disable-optimizations \
+--enable-cross-compile \
+--target-os=win64 \
+--extra-cflags="-MDd" \
+--extra-ldflags="/NODEFAULTLIB:libcmt" \
+--enable-debug \
+--disable-network \
+--disable-autodetect \
+--disable-encoders \
+--disable-decoders \
+--disable-filters \
+--disable-muxers \
+--disable-demuxers \
+--disable-bsfs \
+--disable-parsers \
+--disable-protocols \
+--disable-devices \
+--enable-protocol=file \
+--enable-decoder=h264,mp3*,aac,pcm*,mpeg4 \
+--enable-demuxer=h264,mp4,mp3,avi,mov,aac \
+--enable-parser=h264,aac,mpeg4video \
+--prefix=../../Build/Debug
+
+make -j4
+make install
+
+exit /b 0

--- a/Windows/CopyPDB.bat
+++ b/Windows/CopyPDB.bat
@@ -1,0 +1,8 @@
+REM ### Copy PDB files from source to destination folder
+
+set "FFmpeg_Source_Folder=%~dp0"
+echo FFmpeg_Source_Folder: %FFmpeg_Source_Folder%
+
+set SRC="%FFmpeg_Source_Folder%\..\Output\Debug\" 
+set DST="%FFmpeg_Source_Folder%\..\Build\Debug\bin\"
+for /R %SRC% %%f in (*.pdb) do copy %%f %DST%

--- a/Windows/FFmpeg.autopkg
+++ b/Windows/FFmpeg.autopkg
@@ -14,9 +14,9 @@ nuget
       id = TechSmith.FFmpeg;
       version: 0.0.6;
       title: FFmpeg Library;
-      authors: { TechSmith Corporation };
-      owners: { TechSmith Corporation };
-      licenseUrl: "http://www.techsmith.com";
+      authors: { FFmpeg Project };
+      owners: { FFmpeg Project };
+      licenseUrl: "https://www.ffmpeg.org/legal.html";
       projectUrl: "https://github.com/TechSmith/FFmpeg";
       iconUrl: "http://www.techsmith.com/favicon.ico";
       requireLicenseAcceptance: false;
@@ -29,7 +29,7 @@ nuget
          0.0.3  Build dlls with only codecs we want to support.
          0.0.2  Build dlls with version info.
          0.0.1  Initial release of this nuget package. It is built on FFmpeg 4.2.1 code base."
-      copyright: "Copyright (c) 2019 TechSmith Corporation. All rights reserved.";
+      copyright: "Copyright (c) 2000-2019 FFmpeg Project.";
       tags: { native, tsc, FFmpeg, vs2017, cpp, techsmith };
    };
 

--- a/Windows/FFmpeg.autopkg
+++ b/Windows/FFmpeg.autopkg
@@ -12,7 +12,7 @@ nuget
    nuspec
    {
       id = TechSmith.FFmpeg;
-      version: 0.0.6;
+      version: 1.0.0;
       title: FFmpeg Library;
       authors: { FFmpeg Project };
       owners: { FFmpeg Project };
@@ -23,12 +23,7 @@ nuget
       summary: FFmpeg Library;
       description: @"FFmpeg is a collection of libraries and tools to process multimedia content such as audio, video, subtitles and related metadata. Detailed information can be found here: https://github.com/FFmpeg/FFmpeg FFmpeg Library is built on FFmpeg version 4.2.1.
       Version history:
-         0.0.6  Get all batch and shell script files ready for automated building process.
-         0.0.5  Enable all mp3 decoders.
-         0.0.4  Rename the id to TechSmith.FFmpeg.
-         0.0.3  Build dlls with only codecs we want to support.
-         0.0.2  Build dlls with version info.
-         0.0.1  Initial release of this nuget package. It is built on FFmpeg 4.2.1 code base."
+         1.0.0  Initial release of this nuget package. It is built on FFmpeg 4.2.1 code base."
       copyright: "Copyright (c) 2000-2019 FFmpeg Project.";
       tags: { native, tsc, FFmpeg, vs2017, cpp, techsmith };
    };

--- a/Windows/FFmpeg.autopkg
+++ b/Windows/FFmpeg.autopkg
@@ -1,0 +1,81 @@
+configurations
+{
+   Toolset
+   {
+      key : "PlatformToolset";
+      choices: { v141 };
+   };
+}
+
+nuget
+{
+   nuspec
+   {
+      id = TechSmith.FFmpeg;
+      version: 0.0.5;
+      title: FFmpeg Library;
+      authors: { TechSmith Corporation };
+      owners: { TechSmith Corporation };
+      licenseUrl: "http://www.techsmith.com";
+      projectUrl: "https://github.com/TechSmith/FFmpeg";
+      iconUrl: "http://www.techsmith.com/favicon.ico";
+      requireLicenseAcceptance: false;
+      summary: FFmpeg Library;
+      description: @"FFmpeg is a collection of libraries and tools to process multimedia content such as audio, video, subtitles and related metadata. Detailed information can be found here: https://github.com/FFmpeg/FFmpeg FFmpeg Library is built on FFmpeg version 4.2.1.
+      Version history:
+         0.0.5  Enable all mp3 decoders.
+         0.0.4  Rename the id to TechSmith.FFmpeg.
+         0.0.3  Build dlls with only codecs we want to support.
+         0.0.2  Build dlls with version info.
+         0.0.1  Initial release of this nuget package. It is built on FFmpeg 4.2.1 code base."
+      copyright: "Copyright (c) 2019 TechSmith Corporation. All rights reserved.";
+      tags: { native, tsc, FFmpeg, vs2017, cpp, techsmith };
+   };
+
+   dependencies
+   {
+      packages:
+      {
+      };
+   };
+
+   files
+   {
+      #defines
+      {
+         FFMPEG_BUILD = ..\Build\;
+      }
+
+	  nestedInclude: { #destination = ${d_include}; ${FFMPEG_BUILD}Release\include\**\*.h; }
+	  
+      ("Debug,Release") =>
+      {
+         [${0}]
+         {
+            lib:         { ${FFMPEG_BUILD}${0}\bin\*.lib;}
+
+            bin:         { ${FFMPEG_BUILD}${0}\bin\*.dll;
+                           ${FFMPEG_BUILD}${0}\bin\*.pdb; }
+         };
+      };
+   };
+
+   props
+   {
+      // Additional declarations to insert into consuming projects before most of the
+      // project settings. (These may be modified in visual studio by a developer
+      // consuming this package.)
+      // This node is typically not needed for most packages and may be omitted.
+   }
+
+   targets
+   {
+      // Additional declarations to insert into consuming projects after most of the
+      // project settings. (These may NOT be modified in visual studio by a developer
+      // consuming this package.)
+      // This node is often used to set defines that are required that must be set by
+      // the consuming project in order to correctly link to the libraries in this
+      // package.  Such defines may be set either globally or only set under specific
+      // conditions.
+   }
+}

--- a/Windows/FFmpeg.autopkg
+++ b/Windows/FFmpeg.autopkg
@@ -12,7 +12,7 @@ nuget
    nuspec
    {
       id = TechSmith.FFmpeg;
-      version: 0.0.5;
+      version: 0.0.6;
       title: FFmpeg Library;
       authors: { TechSmith Corporation };
       owners: { TechSmith Corporation };
@@ -23,6 +23,7 @@ nuget
       summary: FFmpeg Library;
       description: @"FFmpeg is a collection of libraries and tools to process multimedia content such as audio, video, subtitles and related metadata. Detailed information can be found here: https://github.com/FFmpeg/FFmpeg FFmpeg Library is built on FFmpeg version 4.2.1.
       Version history:
+         0.0.6  Get all batch and shell script files ready for automated building process.
          0.0.5  Enable all mp3 decoders.
          0.0.4  Rename the id to TechSmith.FFmpeg.
          0.0.3  Build dlls with only codecs we want to support.

--- a/Windows/README.md
+++ b/Windows/README.md
@@ -1,0 +1,250 @@
+# How to Build FFmepg on Windows using Visual Studio 2017
+Instructions for building FFmpeg as shared libraries (dlls) on Windows using Visual Studio 2017.
+
+## Prerequisites and First Time Setup Instructions
+
+### Prerequisites
+* Visual Studio 2017
+* [MSYS2 ](http://msys2.github.io/) (GNU Make environment)
+* [YASM ](http://yasm.tortall.net/Download.html) (x86 assembly code compiler)
+
+### MSYS2 Setup
+Download the latest MSYS2 installer from ​http://msys2.github.io/ and **follow the installation instruction closely** from the installation webpage. For us, we need to download the x86_64 one, NOT the i686 one.
+
+Run the installer and install it to its default folder (eg: we use c:\msys64\ as the installation folder), at the end, run MSYS2 by clicking "Finish" button. And MSYS2 shell command line terminal is open, run the command below:
+
+```Shell
+pacman -Syu
+```
+
+Continue the installation with typing in "Y(es)" when asked. When this round is done, close the ternimal and run MSYS2 again with command below:
+
+```Shell
+pacman -Su 
+```
+
+Continue the installation with typing in "Y(es)" when asked.
+
+Get the latest make package by invoking the following command in your MSYS2 shell
+
+```Shell
+pacman -S make
+```
+
+Install the diffutils for configuring script later
+
+```Shell
+pacman -S diffutils
+```
+
+Install the package configure
+
+```Shell
+pacman -S msys/pkg-config
+```
+
+Close the terminal and we need to do a few tweaks to MSYS2. 
+
+Now open msys2_shell.cmd (which should be found in c:\msys64\ folder) in a text editor, in order for the environment from the Windows side to be inherited on the MSYS2 side, uncomment the following line if it is present: replace rem set MSYS2_PATH_TYPE=inherit with set MSYS2_PATH_TYPE=inherit this will allow the environment variables for Visual Studio to be transferred to the MSYS2 environment and back. Now close the ternimal and reopen it.
+
+Rename link.exe to link_bak.exe in the MSYS2 usr bin folder (E.g. C:\msys64\usr\bin\link.exe) to prevent conflict with MSVC link.exe
+
+Making MSYS2 inherit the Windows PATH values means making sure C:\msys64\msys2.ini looks like this:
+CHERE_INVOKING=1
+MSYS2_PATH_TYPE=inherit
+MSYSTEM=MSYS
+
+MSYS2 should now be fully installed for Windows use.
+
+### YASM Setup
+Download [YASM executable](​http://yasm.tortall.net/Download.html). You have to download the "general use" binaries and NOT the ones for VS2010. Either Win32 or Win64 binaries support outputting object files for both architectures so that should not matter. The last tested version was [yasm-1.3.0-win64.exe](http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe).
+
+Rename the downloaded executable to yasm.exe and place it in your MSYS2 path. E.g.C:\msys64\usr\bin\yasm.exe.
+
+### Verifying your FFmpeg Environment Setup
+Launch x64 Native Tools Command Prompt for VS 2017. E.g. Open Command Prompt, then run command below:
+
+```Shell
+%comspec% /k "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat" x64
+```
+
+Open MSYS2 Shell from the command prompt above (use the correct drive and location of your MSYS2 installation). Note that the command shell above will close and it may take a while for the MSYS2 shell to launch.
+
+```Shell
+C:\msys64\msys2_shell.cmd
+```
+
+In the MSYS2 shell verify that all the tools below are setup properly by running the following commands
+
+```Shell
+$ which cl
+```
+You would see something like this: 
+/c/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.14.26428/bin/HostX64/x64/cl
+
+```Shell
+$ which link
+```
+You would see something like this: 
+/c/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Tools/MSVC/14.14.26428/bin/HostX64/x64/link
+
+```Shell
+$ which yasm
+```
+You would see something like this: 
+/usr/bin/yasm
+
+This verifies that the tools are in the path and point to the right location where MSYS2 and Visual Studio are installed. Now close the terminal for MSYS2.
+
+## Compiling for Windows
+
+Launch x64 Native Tools Command Prompt for VS 2017 if it is not open yet from previous session. E.g. Open Command Prompt, then run command below:
+
+```Shell
+%comspec% /k "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat" x64
+```
+
+Open MSYS2 Shell from the command prompt above (use the correct drive and location of your MSYS2 installation). Note that the command shell above will close and it may take a while for the MSYS2 shell to launch.
+
+```Shell
+C:\msys64\msys2_shell.cmd
+```
+
+In your MSYS2 shell navigate to your cloned FFmpeg folder. E.g.: C:\Git\FFmpeg
+
+```Shell
+cd /c/Git/FFmpeg
+```
+
+Run the configure file to configure the code. Full list of configure options can be found [here](https://github.com/TechSmith/FFmpeg/blob/master/configure) Make sure we build it as LGPL, details on license issues can be found [here](https://www.ffmpeg.org/legal.html)
+
+### Generate release build configre files
+
+Invoke the following make commands
+
+```Shell
+mkdir -p Output/Release
+```
+
+```Shell
+cd Output/Release
+```
+
+```Shell
+../../configure \
+--toolchain=msvc \
+--disable-programs \
+--disable-doc \
+--arch=x86_64 \
+--enable-shared \
+--disable-static \
+--enable-cross-compile \
+--target-os=win64 \
+--extra-cflags="-MD" \
+--disable-debug \
+--disable-network \
+--disable-autodetect \
+--disable-encoders \
+--disable-decoders \
+--disable-filters \
+--disable-muxers \
+--disable-demuxers \
+--disable-bsfs \
+--disable-parsers \
+--disable-protocols \
+--disable-devices \
+--enable-protocol=file \
+--enable-decoder=h264,mp3*,aac,pcm*,mpeg4 \
+--enable-demuxer=h264,mp4,mp3,avi,mov,aac \
+--enable-parser=h264,aac,mpeg4video \
+--prefix=../../Build/Release
+```
+This takes a couple of minutes and you should see no errors when it is done generating config files and the last line should read:
+License: LGPL version 2.1 or later
+
+### Generate debug build configure files
+
+Invoke the following make commands
+
+```Shell
+mkdir -p Output/Debug
+```
+
+```Shell
+cd Output/Debug
+```
+
+```Shell
+../../configure \
+--toolchain=msvc \
+--disable-programs \
+--disable-doc \
+--arch=x86_64 \
+--enable-shared \
+--disable-static \
+--disable-optimizations \
+--enable-cross-compile \
+--target-os=win64 \
+--extra-cflags="-MDd" \
+--extra-ldflags="/NODEFAULTLIB:libcmt" \
+--enable-debug \
+--disable-network \
+--disable-autodetect \
+--disable-encoders \
+--disable-decoders \
+--disable-filters \
+--disable-muxers \
+--disable-demuxers \
+--disable-bsfs \
+--disable-parsers \
+--disable-protocols \
+--disable-devices \
+--enable-protocol=file \
+--enable-decoder=h264,mp3*,aac,pcm*,mpeg4 \
+--enable-demuxer=h264,mp4,mp3,avi,mov,aac \
+--enable-parser=h264,aac,mpeg4video \
+--prefix=../../Build/Debug
+```
+
+This takes a couple of minutes and you should see no errors when it is done generating config files and the last line should read:
+License: LGPL version 2.1 or later
+
+### Build binaries
+
+And we build it by calling "make". Note this will take about 5 to 30 minutes or so to finish depending on the "config" and "make" switches you use.
+```Shell
+make
+```
+You can speed-up compilation using parallel build "make -j4" or the number of cores you want it to use
+
+Then assemble the binaries by calling "make install" and put them in the output folder. This should be very quick and take less than a minute.
+```Shell
+make install
+```
+
+Generated libraries can be found in Build folder specified in --prefix option above.
+
+## Copy PDB and Patch dlls
+
+Make sure FFmpeg\Windows folder is current:
+```Shell
+CopyPDB.bat
+```
+
+```Shell
+VersionPatching.bat
+```
+
+## Build Nuget Package
+
+### Prerequisites
+Make sure you have a nuget packaging tool installed (for instance: coapp). Make sure you have run the steps above and all the FFmpeg binaries are in the Build folder mentioned above.
+
+### Build the nuget package
+Open commad line tool, and ..\FFmpeg\Windows is your current location. Use command below to build the nuget package:
+
+```Shell
+Write-NuGetPackage .\FFmpeg.autopkg
+```
+
+Generated nuget files should be listed in the ..\FFmpeg\Windows folder.

--- a/Windows/README.md
+++ b/Windows/README.md
@@ -101,7 +101,7 @@ This verifies that the tools are in the path and point to the right location whe
 Launch x64 Native Tools Command Prompt for VS 2017 if it is not open yet from previous session. E.g. Open Command Prompt, then run command below:
 
 ```Shell
-%comspec% /k "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat" x64
+%comspec% /k "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
 ```
 
 Open MSYS2 Shell from the command prompt above (use the correct drive and location of your MSYS2 installation). Note that the command shell above will close and it may take a while for the MSYS2 shell to launch.
@@ -224,13 +224,26 @@ make install
 
 Generated libraries can be found in Build folder specified in --prefix option above.
 
-## Copy PDB and Patch dlls
+
+## Automated Compiling for Windows Using Script
+
+Open PowerShell console, make sure FFmpeg\Windows folder is current and run the script below. This will automate the compiling process menioned above:
+```Shell
+.\Build.ps1
+```
+
+# Post-Processing
+
+## Copy PDB files to the detination folder
 
 Make sure FFmpeg\Windows folder is current:
 ```Shell
 CopyPDB.bat
 ```
 
+## Patch the dlls with proper version and copyright info
+
+Download the version patching tool here: https://github.com/pavel-a/ddverpatch/releases , make sure you put it in C drive of your build machine, and this file should look exactly like this: “C:\verpatch\verpatch.exe”. This file is used to patch the version info for FFmpeg dlls built from the steps above. Make sure FFmpeg\Windows folder is current:
 ```Shell
 VersionPatching.bat
 ```
@@ -238,7 +251,7 @@ VersionPatching.bat
 ## Build Nuget Package
 
 ### Prerequisites
-Make sure you have a nuget packaging tool installed (for instance: coapp). Make sure you have run the steps above and all the FFmpeg binaries are in the Build folder mentioned above.
+Make sure you have a nuget packaging tool installed. Make sure you have run the steps above and all the FFmpeg binaries are in the Build folder mentioned above.
 
 ### Build the nuget package
 Open commad line tool, and ..\FFmpeg\Windows is your current location. Use command below to build the nuget package:

--- a/Windows/VersionPatching.bat
+++ b/Windows/VersionPatching.bat
@@ -1,0 +1,37 @@
+REM ### Patch the version
+
+set "FFmpeg_Source_Folder=%~dp0"
+echo FFmpeg_Source_Folder: %FFmpeg_Source_Folder%
+
+
+REM ### Release
+
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avcodec-58.dll" "58.54.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avcodec-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avdevice-58.dll" "58.8.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avdevice-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avfilter-7.dll" "7.57.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avfilter-7.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avformat-58.dll" "58.29.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avformat-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avutil-56.dll" "56.31.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avutil-56.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\swresample-3.dll" "3.5.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swresample-3.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\swscale-5.dll" "5.5.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swscale-5.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+
+REM ### Debug
+     
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avcodec-58.dll" "58.54.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avcodec-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avdevice-58.dll" "58.8.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avdevice-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avfilter-7.dll" "7.57.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avfilter-7.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avformat-58.dll" "58.29.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avformat-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avutil-56.dll" "56.31.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avutil-56.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\swresample-3.dll" "3.5.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swresample-3.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\swscale-5.dll" "5.5.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swscale-5.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"

--- a/Windows/VersionPatching.bat
+++ b/Windows/VersionPatching.bat
@@ -6,32 +6,32 @@ echo FFmpeg_Source_Folder: %FFmpeg_Source_Folder%
 
 REM ### Release
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avcodec-58.dll" "58.54.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avcodec-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avcodec-58.dll" "58.54.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avcodec-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avdevice-58.dll" "58.8.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avdevice-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avdevice-58.dll" "58.8.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avdevice-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avfilter-7.dll" "7.57.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avfilter-7.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avfilter-7.dll" "7.57.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avfilter-7.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avformat-58.dll" "58.29.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avformat-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avformat-58.dll" "58.29.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avformat-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avutil-56.dll" "56.31.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avutil-56.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avutil-56.dll" "56.31.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avutil-56.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\swresample-3.dll" "3.5.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swresample-3.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\swresample-3.dll" "3.5.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swresample-3.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\swscale-5.dll" "5.5.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swscale-5.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\swscale-5.dll" "5.5.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swscale-5.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
 REM ### Debug
      
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avcodec-58.dll" "58.54.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avcodec-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avcodec-58.dll" "58.54.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avcodec-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avdevice-58.dll" "58.8.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avdevice-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avdevice-58.dll" "58.8.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avdevice-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avfilter-7.dll" "7.57.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avfilter-7.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avfilter-7.dll" "7.57.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avfilter-7.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avformat-58.dll" "58.29.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avformat-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avformat-58.dll" "58.29.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avformat-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avutil-56.dll" "56.31.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avutil-56.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avutil-56.dll" "56.31.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avutil-56.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\swresample-3.dll" "3.5.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swresample-3.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\swresample-3.dll" "3.5.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swresample-3.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\swscale-5.dll" "5.5.100.0" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swscale-5.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\swscale-5.dll" "5.5.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swscale-5.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"


### PR DESCRIPTION
This FFmpeg repo is a forked branch and based on version 4.2.1 code. The binaries from this branch are built with LGPL compliance (https://github.com/TechSmith/FFmpeg/pull/1/files#diff-f9ca60ea81d2a927db6d4f993f4c5240R15). It currently enables only decoding support for codecs below:
* AAC
* MP3
* H264/MPEG-4  

- [x] It builds both on local machine and on build server
- [x] It is able to publish the nuget package to the nuget source server
- [x] Verified the dlls were versioned correctly
- [x] Verified the nuget package works with our test project
- [x] Added ReadMe.md instructions for building the binaries with Visual Studio 2017