### PR TITLE
Turn on hardware decoding for H264

### DIFF
--- a/Windows/Build.sh
+++ b/Windows/Build.sh
@@ -37,6 +37,8 @@ cd Output/Release
 --enable-decoder=h264,mp3*,aac,pcm*,mpeg4 \
 --enable-demuxer=h264,mp4,mp3,avi,mov,aac \
 --enable-parser=h264,aac,mpeg4video \
+--enable-d3d11va \
+--enable-hwaccel=h264_d3d11va \
 --prefix=../../Build/Release
 
 make -j4
@@ -74,6 +76,8 @@ cd Debug
 --enable-decoder=h264,mp3*,aac,pcm*,mpeg4 \
 --enable-demuxer=h264,mp4,mp3,avi,mov,aac \
 --enable-parser=h264,aac,mpeg4video \
+--enable-d3d11va \
+--enable-hwaccel=h264_d3d11va \
 --prefix=../../Build/Debug
 
 make -j4

--- a/Windows/FFmpeg.autopkg
+++ b/Windows/FFmpeg.autopkg
@@ -12,7 +12,7 @@ nuget
    nuspec
    {
       id = TechSmith.FFmpeg;
-      version: 1.0.0;
+      version: 1.0.1;
       title: FFmpeg Library;
       authors: { FFmpeg Project };
       owners: { FFmpeg Project };
@@ -23,6 +23,7 @@ nuget
       summary: FFmpeg Library;
       description: @"FFmpeg is a collection of libraries and tools to process multimedia content such as audio, video, subtitles and related metadata. Detailed information can be found here: https://github.com/FFmpeg/FFmpeg FFmpeg Library is built on FFmpeg version 4.2.1.
       Version history:
+         1.0.1  Enable hardware decoding for H264.
          1.0.0  Initial release of this nuget package. It is built on FFmpeg 4.2.1 code base."
       copyright: "Copyright (c) 2000-2019 FFmpeg Project.";
       tags: { native, tsc, FFmpeg, vs2017, cpp, techsmith };

--- a/Windows/README.md
+++ b/Windows/README.md
@@ -157,6 +157,8 @@ cd Output/Release
 --enable-decoder=h264,mp3*,aac,pcm*,mpeg4 \
 --enable-demuxer=h264,mp4,mp3,avi,mov,aac \
 --enable-parser=h264,aac,mpeg4video \
+--enable-d3d11va \
+--enable-hwaccel=h264_d3d11va \
 --prefix=../../Build/Release
 ```
 This takes a couple of minutes and you should see no errors when it is done generating config files and the last line should read:
@@ -203,6 +205,8 @@ cd Output/Debug
 --enable-decoder=h264,mp3*,aac,pcm*,mpeg4 \
 --enable-demuxer=h264,mp4,mp3,avi,mov,aac \
 --enable-parser=h264,aac,mpeg4video \
+--enable-d3d11va \
+--enable-hwaccel=h264_d3d11va \
 --prefix=../../Build/Debug
 ```
 

--- a/Windows/VersionPatching.bat
+++ b/Windows/VersionPatching.bat
@@ -6,32 +6,32 @@ echo FFmpeg_Source_Folder: %FFmpeg_Source_Folder%
 
 REM ### Release
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avcodec-58.dll" "58.54.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avcodec-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avcodec-58.dll" "58.54.100.2" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avcodec-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avdevice-58.dll" "58.8.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avdevice-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avdevice-58.dll" "58.8.100.2" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avdevice-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avfilter-7.dll" "7.57.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avfilter-7.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avfilter-7.dll" "7.57.100.2" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avfilter-7.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avformat-58.dll" "58.29.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avformat-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avformat-58.dll" "58.29.100.2" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avformat-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avutil-56.dll" "56.31.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avutil-56.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avutil-56.dll" "56.31.100.2" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avutil-56.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\swresample-3.dll" "3.5.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swresample-3.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\swresample-3.dll" "3.5.100.2" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swresample-3.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\swscale-5.dll" "5.5.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swscale-5.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\swscale-5.dll" "5.5.100.2" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swscale-5.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
 REM ### Debug
      
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avcodec-58.dll" "58.54.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avcodec-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avcodec-58.dll" "58.54.100.2" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avcodec-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avdevice-58.dll" "58.8.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avdevice-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avdevice-58.dll" "58.8.100.2" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avdevice-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avfilter-7.dll" "7.57.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avfilter-7.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avfilter-7.dll" "7.57.100.2" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avfilter-7.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avformat-58.dll" "58.29.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avformat-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avformat-58.dll" "58.29.100.2" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avformat-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avutil-56.dll" "56.31.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avutil-56.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avutil-56.dll" "56.31.100.2" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avutil-56.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\swresample-3.dll" "3.5.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swresample-3.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\swresample-3.dll" "3.5.100.2" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swresample-3.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\swscale-5.dll" "5.5.100.1" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swscale-5.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\swscale-5.dll" "5.5.100.2" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swscale-5.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"


### PR DESCRIPTION
Turn on hardware decoding for H264 in build config file, and also bump up versions for dlls and nuget package. Currently only D3D11VA is turned on.