### PR TITLE
Fix casing of libmp3lame.dll

### DIFF
--- a/Windows/BuildLame.ps1
+++ b/Windows/BuildLame.ps1
@@ -15,7 +15,7 @@ if (![System.IO.File]::Exists($msbuild))
 }
 
 # from FFmpeg\Windows
-$LameRoot = "../libmp3Lame"
+$LameRoot = "../libmp3lame"
 $lameSln = "$LameRoot/vc_solution/Lame.sln"
 
 # build $lameSln for debug mode

--- a/Windows/CopyLameToBuildFolderForFFmpegToMakeNugetPackage.ps1
+++ b/Windows/CopyLameToBuildFolderForFFmpegToMakeNugetPackage.ps1
@@ -1,7 +1,7 @@
 
 # copy Lame header/libs/dlls to the Build folder for FFmpeg to make nuget package
 $FFmpegBuildFolder = "../Build"
-$LameRoot = "../libmp3Lame"
+$LameRoot = "../libmp3lame"
 
 # create the output folder structure
 Remove-Item "$FFmpegBuildFolder/Debug/include/lame" -ErrorAction Ignore -Force -Recurse
@@ -17,12 +17,12 @@ copy-item -Path "$LameRoot/include/lame.h" -Destination "$FFmpegBuildFolder/Rele
 
 # note we the dll name is unchanged
 Write-Host "Copying dlls..."
-copy-item -Path "$LameRoot/redist/x64/Debug/libmp3lame.dll" -Destination "$FFmpegBuildFolder/Debug/bin/libmp3Lame.dll" -Force
+copy-item -Path "$LameRoot/redist/x64/Debug/libmp3lame.dll" -Destination "$FFmpegBuildFolder/Debug/bin/libmp3lame.dll" -Force
 copy-item -Path "$LameRoot/redist/x64/Release/libmp3lame.dll" -Destination "$FFmpegBuildFolder/Release/bin/libmp3lame.dll" -Force
 
 # note we the pdb name is unchanged
 Write-Host "Copying pdb..."
-copy-item -Path "$LameRoot/redist/x64/Debug/libmp3lame.pdb" -Destination "$FFmpegBuildFolder/Debug/bin/libmp3Lame.pdb" -Force
+copy-item -Path "$LameRoot/redist/x64/Debug/libmp3lame.pdb" -Destination "$FFmpegBuildFolder/Debug/bin/libmp3lame.pdb" -Force
 
 # note we the lib name is changed
 Write-Host "Copying libs..."

--- a/Windows/CopyLameToOutputFolderForFFmpegToBuild.ps1
+++ b/Windows/CopyLameToOutputFolderForFFmpegToBuild.ps1
@@ -1,5 +1,5 @@
 
-$LameRoot = "../libmp3Lame"
+$LameRoot = "../libmp3lame"
 
 # copy header/libs/dlls to the output folder for FFmpeg to consume
 $lameOutputForFFmpeg = "$LameRoot/output"
@@ -18,12 +18,12 @@ copy-item -Path "$LameRoot/include/lame.h" -Destination "$lameOutputForFFmpeg/la
 
 # note we the dll name is unchanged
 Write-Host "Copying dlls..."
-copy-item -Path "$LameRoot/redist/x64/Debug/libmp3lame.dll" -Destination "$lameOutputForFFmpeg/x64/Debug/libmp3Lame.dll" -Force
+copy-item -Path "$LameRoot/redist/x64/Debug/libmp3lame.dll" -Destination "$lameOutputForFFmpeg/x64/Debug/libmp3lame.dll" -Force
 copy-item -Path "$LameRoot/redist/x64/Release/libmp3lame.dll" -Destination "$lameOutputForFFmpeg/x64/Release/libmp3lame.dll" -Force
 
 # note we the pdb name is unchanged
 Write-Host "Copying pdb..."
-copy-item -Path "$LameRoot/redist/x64/Debug/libmp3lame.pdb" -Destination "$lameOutputForFFmpeg/x64/Debug/libmp3Lame.pdb" -Force
+copy-item -Path "$LameRoot/redist/x64/Debug/libmp3lame.pdb" -Destination "$lameOutputForFFmpeg/x64/Debug/libmp3lame.pdb" -Force
 
 # note we the lib name is changed - this is needed for FFmpeg to find and link to the lib correctly
 Write-Host "Copying libs..."

--- a/Windows/FFmpeg.autopkg
+++ b/Windows/FFmpeg.autopkg
@@ -12,7 +12,7 @@ nuget
    nuspec
    {
       id = TechSmith.FFmpeg;
-      version: 1.0.4;
+      version: 1.0.4-pre1;
       title: FFmpeg Library;
       authors: { FFmpeg Project };
       owners: { FFmpeg Project };

--- a/Windows/FFmpeg.autopkg
+++ b/Windows/FFmpeg.autopkg
@@ -12,7 +12,7 @@ nuget
    nuspec
    {
       id = TechSmith.FFmpeg;
-      version: 1.0.3;
+      version: 1.0.4;
       title: FFmpeg Library;
       authors: { FFmpeg Project };
       owners: { FFmpeg Project };
@@ -23,6 +23,7 @@ nuget
       summary: FFmpeg Library;
       description: @"FFmpeg is a collection of libraries and tools to process multimedia content such as audio, video, subtitles and related metadata. Detailed information can be found here: https://github.com/FFmpeg/FFmpeg FFmpeg Library is built on FFmpeg version 4.2.1.
       Version history:
+         1.0.4  Fix casing of libmp3lame.dll
          1.0.3  Enable MP3 encoding. Also remove H264, AAC decoders.
          1.0.1  Enable hardware decoding for H264.
          1.0.0  Initial release of this nuget package. It is built on FFmpeg 4.2.1 code base."

--- a/Windows/FFmpeg.autopkg
+++ b/Windows/FFmpeg.autopkg
@@ -12,7 +12,7 @@ nuget
    nuspec
    {
       id = TechSmith.FFmpeg;
-      version: 1.0.4-pre1;
+      version: 1.0.4;
       title: FFmpeg Library;
       authors: { FFmpeg Project };
       owners: { FFmpeg Project };

--- a/Windows/VersionPatchingForFFmpegDlls.bat
+++ b/Windows/VersionPatchingForFFmpegDlls.bat
@@ -2,37 +2,37 @@ REM ### Patch the version
 
 set "FFmpeg_Source_Folder=%~dp0"
 echo FFmpeg_Source_Folder: %FFmpeg_Source_Folder%
-set VersionString="4.2.1.1"
-
+set FFmpegVersionString="4.2.1.0"
+set DLLBuildVersion=5
 
 REM ### Release
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avcodec-58.dll" "58.54.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avcodec-58.dll" /s ProductName "FFmpeg" /pv %VersionString%
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avcodec-58.dll" "58.54.100.%DLLBuildVersion%" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avcodec-58.dll" /s ProductName "FFmpeg" /pv %FFmpegVersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avdevice-58.dll" "58.8.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avdevice-58.dll" /s ProductName "FFmpeg" /pv %VersionString%
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avdevice-58.dll" "58.8.100.%DLLBuildVersion%" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avdevice-58.dll" /s ProductName "FFmpeg" /pv %FFmpegVersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avfilter-7.dll" "7.57.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avfilter-7.dll" /s ProductName "FFmpeg" /pv %VersionString%
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avfilter-7.dll" "7.57.100.%DLLBuildVersion%" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avfilter-7.dll" /s ProductName "FFmpeg" /pv %FFmpegVersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avformat-58.dll" "58.29.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avformat-58.dll" /s ProductName "FFmpeg" /pv %VersionString%
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avformat-58.dll" "58.29.100.%DLLBuildVersion%" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avformat-58.dll" /s ProductName "FFmpeg" /pv %FFmpegVersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avutil-56.dll" "56.31.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avutil-56.dll" /s ProductName "FFmpeg" /pv %VersionString%
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avutil-56.dll" "56.31.100.%DLLBuildVersion%" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avutil-56.dll" /s ProductName "FFmpeg" /pv %FFmpegVersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\swresample-3.dll" "3.5.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swresample-3.dll" /s ProductName "FFmpeg" /pv %VersionString%
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\swresample-3.dll" "3.5.100.%DLLBuildVersion%" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swresample-3.dll" /s ProductName "FFmpeg" /pv %FFmpegVersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\swscale-5.dll" "5.5.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swscale-5.dll" /s ProductName "FFmpeg" /pv %VersionString%
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\swscale-5.dll" "5.5.100.%DLLBuildVersion%" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swscale-5.dll" /s ProductName "FFmpeg" /pv %FFmpegVersionString%
 
 REM ### Debug
      
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avcodec-58.dll" "58.54.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avcodec-58.dll" /s ProductName "FFmpeg" /pv %VersionString%
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avcodec-58.dll" "58.54.100.%DLLBuildVersion%" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avcodec-58.dll" /s ProductName "FFmpeg" /pv %FFmpegVersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avdevice-58.dll" "58.8.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avdevice-58.dll" /s ProductName "FFmpeg" /pv %VersionString%
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avdevice-58.dll" "58.8.100.%DLLBuildVersion%" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avdevice-58.dll" /s ProductName "FFmpeg" /pv %FFmpegVersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avfilter-7.dll" "7.57.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avfilter-7.dll" /s ProductName "FFmpeg" /pv %VersionString%
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avfilter-7.dll" "7.57.100.%DLLBuildVersion%" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avfilter-7.dll" /s ProductName "FFmpeg" /pv %FFmpegVersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avformat-58.dll" "58.29.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avformat-58.dll" /s ProductName "FFmpeg" /pv %VersionString%
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avformat-58.dll" "58.29.100.%DLLBuildVersion%" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avformat-58.dll" /s ProductName "FFmpeg" /pv %FFmpegVersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avutil-56.dll" "56.31.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avutil-56.dll" /s ProductName "FFmpeg" /pv %VersionString%
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avutil-56.dll" "56.31.100.%DLLBuildVersion%" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avutil-56.dll" /s ProductName "FFmpeg" /pv %FFmpegVersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\swresample-3.dll" "3.5.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swresample-3.dll" /s ProductName "FFmpeg" /pv %VersionString%
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\swresample-3.dll" "3.5.100.%DLLBuildVersion%" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swresample-3.dll" /s ProductName "FFmpeg" /pv %FFmpegVersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\swscale-5.dll" "5.5.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swscale-5.dll" /s ProductName "FFmpeg" /pv %VersionString%
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\swscale-5.dll" "5.5.100.%DLLBuildVersion%" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swscale-5.dll" /s ProductName "FFmpeg" /pv %FFmpegVersionString%

--- a/Windows/VersionPatchingForFFmpegDlls.bat
+++ b/Windows/VersionPatchingForFFmpegDlls.bat
@@ -2,36 +2,37 @@ REM ### Patch the version
 
 set "FFmpeg_Source_Folder=%~dp0"
 echo FFmpeg_Source_Folder: %FFmpeg_Source_Folder%
+set VersionString="4.2.1.1"
 
 
 REM ### Release
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avcodec-58.dll" "58.54.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avcodec-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avcodec-58.dll" "58.54.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avcodec-58.dll" /s ProductName "FFmpeg" /pv %VersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avdevice-58.dll" "58.8.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avdevice-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avdevice-58.dll" "58.8.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avdevice-58.dll" /s ProductName "FFmpeg" /pv %VersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avfilter-7.dll" "7.57.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avfilter-7.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avfilter-7.dll" "7.57.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avfilter-7.dll" /s ProductName "FFmpeg" /pv %VersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avformat-58.dll" "58.29.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avformat-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avformat-58.dll" "58.29.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avformat-58.dll" /s ProductName "FFmpeg" /pv %VersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avutil-56.dll" "56.31.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avutil-56.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\avutil-56.dll" "56.31.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avutil-56.dll" /s ProductName "FFmpeg" /pv %VersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\swresample-3.dll" "3.5.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swresample-3.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\swresample-3.dll" "3.5.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swresample-3.dll" /s ProductName "FFmpeg" /pv %VersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\swscale-5.dll" "5.5.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swscale-5.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Release\bin\swscale-5.dll" "5.5.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swscale-5.dll" /s ProductName "FFmpeg" /pv %VersionString%
 
 REM ### Debug
      
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avcodec-58.dll" "58.54.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avcodec-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avcodec-58.dll" "58.54.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avcodec-58.dll" /s ProductName "FFmpeg" /pv %VersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avdevice-58.dll" "58.8.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avdevice-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avdevice-58.dll" "58.8.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avdevice-58.dll" /s ProductName "FFmpeg" /pv %VersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avfilter-7.dll" "7.57.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avfilter-7.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avfilter-7.dll" "7.57.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avfilter-7.dll" /s ProductName "FFmpeg" /pv %VersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avformat-58.dll" "58.29.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avformat-58.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avformat-58.dll" "58.29.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avformat-58.dll" /s ProductName "FFmpeg" /pv %VersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avutil-56.dll" "56.31.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avutil-56.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\avutil-56.dll" "56.31.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "avutil-56.dll" /s ProductName "FFmpeg" /pv %VersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\swresample-3.dll" "3.5.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swresample-3.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\swresample-3.dll" "3.5.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swresample-3.dll" /s ProductName "FFmpeg" /pv %VersionString%
 
-C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\swscale-5.dll" "5.5.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swscale-5.dll" /s ProductName "FFmpeg" /pv "4.2.1.0"
+C:\verpatch\verpatch.exe "%FFmpeg_Source_Folder%\..\Build\Debug\bin\swscale-5.dll" "5.5.100.4" /va /s description "FFmpeg codec library" /s copyright "(C) 2000-2019 FFmpeg Project" /s OriginalFilename "swscale-5.dll" /s ProductName "FFmpeg" /pv %VersionString%


### PR DESCRIPTION
The build scripts were resulting in a dll named `libmp3Lame.dll` instead of `libmp3lame.dll`

I built the nuget package on TeamCity and it successfully published to `1.0.4-pre1`